### PR TITLE
openid.claimed_id is now given an https url

### DIFF
--- a/steamauthOOP.class.php
+++ b/steamauthOOP.class.php
@@ -94,7 +94,7 @@ class steamauthOOP {
         $result = file_get_contents("https://steamcommunity.com/openid/login", false, $context);
 
         // Validate wheather it's true and if we have a good ID
-        preg_match("#^http://steamcommunity.com/openid/id/([0-9]{17,25})#", $_GET['openid_claimed_id'], $matches);
+        preg_match("#^https?://steamcommunity.com/openid/id/([0-9]{17,25})#", $_GET['openid_claimed_id'], $matches);
         $steamID64 = is_numeric($matches[1]) ? $matches[1] : 0;
 
         // Return our final value


### PR DESCRIPTION
Steam has started returning an https steamcommunity url in the claimed id field.